### PR TITLE
feat: ^a.b.c vs ~a.b.c in package.json file

### DIFF
--- a/contents/caret-vs-tilde-in-package-json-file.mdx
+++ b/contents/caret-vs-tilde-in-package-json-file.mdx
@@ -1,0 +1,41 @@
+---
+category: JavaScript
+created: '2023-08-29'
+description: The differences between caret (^) and tilde (~) in package.json file
+openGraphCover: /og/this-vs-that/caret-vs-tilde.png
+title: ^a.b.c vs ~a.b.c in package.json file
+---
+
+When working with [Node Package Manager](https://www.npmjs.com) (NPM), you might come across two symbols in the `package.json` file for specifying package versions - the caret (`^`) and the tilde (`~`). These symbols are used to indicate the acceptable range of package versions.
+
+But before we dive into the differences between them, let's first take a look at the standard for version naming.
+
+## Semver
+
+If you're using packages in NPM, you've probably heard of [semver](https://semver.org). It's a version naming system that makes it easy to understand the significance of different versions of a package.
+
+In semver, each version is made up of three numbers separated by dots - `MAJOR.MINOR.PATCH`.
+
+The `MAJOR` number goes up when there are breaking changes to the package, the `MINOR` number increases when new features are added without breaking anything, and the `PATCH` number goes up when only bug fixes are included.
+
+Understanding semver can help you make informed choices about which versions of a package to use in your project and how to specify acceptable ranges of versions using `^` and `~` in your package.json file.
+
+## The caret (^)
+
+In your `package.json` file, if you see a caret symbol before a version number, it means that NPM is cool with accepting any version of the package that works with the specified version number. Basically, compatible versions are those that have the same major version as the specified version number, but can have any minor or patch version number.
+
+Let's say you put `^1.2.3` as the version number for a package in your `package.json` file. NPM will accept any package version that has a major version of 1, but can have any minor or patch version number. This means that NPM will accept versions like `1.3.0`, `1.4.5`, and `1.99.99`, but not versions like `0.9.9` or `2.0.0`.
+
+## The tilde (~)
+
+When you see a tilde symbol before a version number in the `package.json` file, it means that NPM will accept any package version that's compatible with the specified version number. But there's a catch: it **restricts the minor version number**. Compatible versions must have the same major and minor version as the specified version, but can have any patch version number.
+
+For instance, if you set `~1.2.3` as the version number for a package in your `package.json` file, NPM will accept any package version with a major version of 1 and a minor version of 2, but it can have any patch version number. This means that NPM will allow versions like `1.2.0`, `1.2.4`, and `1.2.99`, but not versions like `1.3.0` or `2.0.0`.
+
+## Conclusion
+
+To sum up, when working with NPM, the caret and tilde symbols in the `package.json` file are crucial to specify the acceptable range of versions for a package. The caret enables any minor or patch version, whereas the tilde restricts the minor version but allows any patch version. Understanding these symbols is critical because they can impact the compatibility and stability of your project.
+
+## See also
+
+-   [dev vs devDependencies vs peerDependencies in package.json](https://phuoc.ng/collection/this-vs-that/dev-vs-dev-dependencies-vs-peer-dependencies-in-package-json)


### PR DESCRIPTION
https://phuoc.ng/collection/this-vs-that/caret-vs-tilde-in-package-json-file/

fixes #180 